### PR TITLE
More polish

### DIFF
--- a/my-profile-api/src/main/java/edu/wisc/my/profile/model/ContactInformation.java
+++ b/my-profile-api/src/main/java/edu/wisc/my/profile/model/ContactInformation.java
@@ -12,7 +12,7 @@ public class ContactInformation {
   private String legalName;
   private String preferredName;
   private String relationship;
-  private List<TypeValue> languages;
+  private String comments;
   private List<TypeValue> phoneNumbers = new ArrayList<TypeValue>();
   private List<TypeValue> emails = new ArrayList<TypeValue>();
   private List<ContactAddress> addresses = new ArrayList<ContactAddress>();
@@ -65,11 +65,11 @@ public class ContactInformation {
   public void setRelationship(String relationship) {
     this.relationship = relationship;
   }
-  public List<TypeValue> getLanguages() {
-    return languages;
+  public String getComments() {
+    return comments;
   }
-  public void setLanguages(List<TypeValue> languages) {
-    this.languages = languages;
+  public void setComments(String comments) {
+    this.comments = comments;
   }
   public boolean isEdit() {
     return edit;

--- a/my-profile-webapp/src/main/webapp/css/app.less
+++ b/my-profile-webapp/src/main/webapp/css/app.less
@@ -24,6 +24,28 @@
     background-color:#fff;
   }
 }
+
+.emergency-info {
+  max-width:350px;
+  #name,
+  .phone-number,
+  .languages
+  {
+    width:100%;
+    display:block;
+  }
+  #email {
+    max-width:250px;
+  }
+  #relationship {
+    max-width:150px;
+  }
+  .phone-type {
+    padding-left:15px;
+  }
+}
+
+
 .top-info {
   text-align:center;
   font-size:18px;

--- a/my-profile-webapp/src/main/webapp/css/app.less
+++ b/my-profile-webapp/src/main/webapp/css/app.less
@@ -29,7 +29,7 @@
   max-width:350px;
   #name,
   .phone-number,
-  .languages
+  #comments
   {
     width:100%;
     display:block;
@@ -158,11 +158,20 @@ address{
   right: 0;
 }
 
-form .ng-invalid {
+form .ng-invalid,
+form .has-error {
   border-color : #b70101;
 }
 form .ng-valid {
   border-color : #5cb85c;
+}
+form .ng-pristine {
+  border-color : #ccc;
+}
+form .form-help {
+  color:#b70101;
+  padding:3px 10px;
+  font-size:12px;
 }
 .admin-lookup-form input {
   padding:4px 10px;

--- a/my-profile-webapp/src/main/webapp/my-app.js
+++ b/my-profile-webapp/src/main/webapp/my-app.js
@@ -184,12 +184,13 @@
       
       app.controller('EmergencyInformationController', ['$localStorage','$scope', 'profileService', function($localStorage, $scope, profileService) {
         $scope.addEdit = function() {
-          $scope.emergencyInfo.push({ preferredName : "", addresses : [{addressLines:[""]}], emails:[{"type":"primary"}], phoneNumbers : [""], languages : [""], edit : true});
+          $scope.emergencyInfo.push({ preferredName : "", addresses : [{addressLines:[""]}], emails:[{"type":"primary"}], phoneNumbers : [""], edit : true});
         }
         
         $scope.save = function() {
             $scope.notSaving = false;
             $scope.error = "";
+            
             profileService.saveEmergencyContactInfo($scope.emergencyInfo)
                 .then(function(result){//success
                     $scope.emergencyInfo = result.data;

--- a/my-profile-webapp/src/main/webapp/partials/emergency.html
+++ b/my-profile-webapp/src/main/webapp/partials/emergency.html
@@ -20,13 +20,13 @@
             <label for="name">Name</label>
             <input class="form-control" id='name' type='text' required ng-model="contact.preferredName">
         </div>
-        <div ng-repeat="phone in contact.phoneNumbers | limitTo:3 track by $index" class="form-group">
+        <div ng-repeat="phone in contact.phoneNumbers | limitTo:3 track by $index" class="form-group phone-number">
             <div class="col-xs-7 no-padding">
                 <label for="phone{{$index}}">Phone</label>
                 <input type="tel" id="phone{{$index}}" required class="form-control" placeholder="i.e. 123-456-7890" ng-model="contact.phoneNumbers[$index].value" ng-if="$index === 0">
                 <input type="tel" id="phone{{$index}}" class="form-control" placeholder="i.e. 123-456-7890" ng-model="contact.phoneNumbers[$index].value" ng-if="$index !== 0">
             </div>
-            <div class="col-xs-5">
+            <div class="col-xs-5 no-padding phone-type">
                 <label for="phone-type{{$index}}">Type</label>
                 <select id="phone-type{{$index}}" class="form-control" required ng-model="contact.phoneNumbers[$index].type">
                     <option value="mobile" selected="selected">Mobile</option>
@@ -45,7 +45,7 @@
             <label for="relationship">Relationship</label>
             <input class="form-control" id='relationship' type='text' required ng-model="contact.relationship">
         </div>
-        <div ng-repeat="phone in contact.languages | limitTo:2 track by $index" class="form-group">
+        <div ng-repeat="phone in contact.languages | limitTo:2 track by $index" class="form-group languages">
             <label for="language{{$index}}" ng-if="$index === 0">First Language</label>
             <input type="text" id="language{{$index}}" required class="form-control" placeholder="i.e. English" ng-model="contact.languages[$index].value" ng-if="$index === 0">
             <label for="language{{$index}}" ng-if="$index !== 0">Second Language</label>

--- a/my-profile-webapp/src/main/webapp/partials/emergency.html
+++ b/my-profile-webapp/src/main/webapp/partials/emergency.html
@@ -1,13 +1,12 @@
 <div ng-if='!contact.edit || contact.edit == false'>
     <p>{{ contact.preferredName }}</p>
     <div ng-repeat="phone in contact.phoneNumbers">
-        <p>{{ phone.value }} ({{ phone.type }})</p>
+        <p><span ng-if="$index === 0">Primary Phone: </span>{{ phone.value }} ({{ phone.type }})</p>
     </div>
     <p>{{ contact.emails[0].value }}</p>
     <br>
     <p ng-if="contact.relationship">Relationship: {{ contact.relationship }}</p>
-    <p ng-if="contact.languages[0]">First Language: {{ contact.languages[0].value }}</p>
-    <p ng-if="contact.languages[1]">Second Language: {{ contact.languages[1].value }}</p>
+    <p ng-if="contact.comments">Comments: {{ contact.comments }}</p>
     <span ng-hide='contact.readOnly'>
         <button class='btn btn-primary' ng-click='addEdit()'>Add another</button>
         <button class='btn btn-default' ng-click='contact.edit = true'>Edit</button>
@@ -15,45 +14,58 @@
     </span>
 </div>
 <div ng-if='contact.edit'>
-    <form novalidate class="emergency-info">
+    <form name="emergencyForm" novalidate class="emergency-info">
         <div class="form-group">
-            <label for="name">Name</label>
-            <input class="form-control" id='name' type='text' required ng-model="contact.preferredName">
+            <label for="name">Name*</label>
+            <input class="form-control" id='name' name="name" type='text' required ng-model="contact.preferredName" ng-class="{ 'has-error' : emergencyForm.name.$invalid && emergencyForm.name.$touched }">
+            <p class="form-help" ng-show="emergencyForm.name.$invalid && emergencyForm.name.$touched">Name is required</p>
         </div>
         <div ng-repeat="phone in contact.phoneNumbers | limitTo:3 track by $index" class="form-group phone-number">
             <div class="col-xs-7 no-padding">
-                <label for="phone{{$index}}">Phone</label>
-                <input type="tel" id="phone{{$index}}" required class="form-control" placeholder="i.e. 123-456-7890" ng-model="contact.phoneNumbers[$index].value" ng-if="$index === 0">
-                <input type="tel" id="phone{{$index}}" class="form-control" placeholder="i.e. 123-456-7890" ng-model="contact.phoneNumbers[$index].value" ng-if="$index !== 0">
+                <label for="phone{{$index}}" ng-if="$index === 0">Primary Phone*</label>
+                <input type="tel" id="phone{{$index}}" name="phone{{$index}}" required class="form-control" ng-model="contact.phoneNumbers[$index].value" ng-if="$index === 0" ng-class="{ 'has-error' : emergencyForm.phone0.$invalid && emergencyForm.phone0.$touched }">
+                <label for="phone{{$index}}" ng-if="$index === 1">Secondary Phone</label>
+                <label for="phone{{$index}}" ng-if="$index === 2">Tertiary Phone</label>
+                <input type="tel" id="phone{{$index}}" class="form-control" ng-model="contact.phoneNumbers[$index].value" ng-if="$index !== 0">
             </div>
             <div class="col-xs-5 no-padding phone-type">
-                <label for="phone-type{{$index}}">Type</label>
-                <select id="phone-type{{$index}}" class="form-control" required ng-model="contact.phoneNumbers[$index].type">
+                <label for="phoneType{{$index}}" ng-if="$index === 0">Type*</label>
+                <label for="phoneType{{$index}}" ng-if="$index !== 0">Type</label>
+                <select id="phoneType{{$index}}" name="phoneType{{$index}}" class="form-control" required ng-model="contact.phoneNumbers[$index].type" ng-class="{ 'has-error' : emergencyForm.phoneType0.$invalid && emergencyForm.phoneType0.$touched }">
                     <option value="mobile" selected="selected">Mobile</option>
                     <option value="home">Home</option>
                     <option value="work">Work</option>
                     <option value="other">Other</option>
                 </select>
             </div>
+            <p class="form-help" ng-show="emergencyForm.phone0.$invalid && emergencyForm.phone0.$touched && $index === 0">Phone number is required</p>
+            <p class="form-help" ng-show="emergencyForm.phoneType0.$invalid && emergencyForm.phoneType0.$touched && $index === 0">Phone type is required</p>
         </div>
         <button class="btn btn-default" type="text" ng-click="contact.phoneNumbers.push('')">Add another phone number</button>
         <div class="form-group">
-            <label for="email">Email</label>
-            <input class="form-control" id='email' type='text' required ng-model="contact.emails[0].value">
+            <label for="email">Email*</label>
+            <input class="form-control" id='email' name="email" type='text' required ng-model="contact.emails[0].value" ng-class="{ 'has-error' : emergencyForm.email.$invalid && emergencyForm.email.$touched }">
+            <p class="form-help" ng-show="emergencyForm.email.$invalid && emergencyForm.email.$touched">Email is required</p>
         </div>
         <div class="form-group">
-            <label for="relationship">Relationship</label>
-            <input class="form-control" id='relationship' type='text' required ng-model="contact.relationship">
+            <label for="relationship">Relationship*</label>
+            <input class="form-control" id='relationship' name="relationship" type='text' required ng-model="contact.relationship" ng-class="{ 'has-error' : emergencyForm.relationship.$invalid && emergencyForm.relationship.$touched }">
+            <p class="form-help" ng-show="emergencyForm.relationship.$invalid && emergencyForm.relationship.$touched">Relationship is required</p>
         </div>
-        <div ng-repeat="phone in contact.languages | limitTo:2 track by $index" class="form-group languages">
+        <div class="form-group">
+            <label for="comments">Communication Considerations / Other Comments</label>
+            <textarea class="form-control" id='comments' type='text' ng-model="contact.comments" placeholder="i.e. Speaks Spanish"></textarea>
+        </div>
+        <p>(*) = Required</p>
+        <!-- <div ng-repeat="phone in contact.languages | limitTo:2 track by $index" class="form-group languages">
             <label for="language{{$index}}" ng-if="$index === 0">First Language</label>
             <input type="text" id="language{{$index}}" required class="form-control" placeholder="i.e. English" ng-model="contact.languages[$index].value" ng-if="$index === 0">
             <label for="language{{$index}}" ng-if="$index !== 0">Second Language</label>
             <input type="tel" id="language{{$index}}" class="form-control" placeholder="i.e. Spanish" ng-model="contact.languages[$index].value" ng-if="$index !== 0">
-        </div>
-        <button class="btn btn-default" type="text" ng-click="contact.languages.push('')">Add another language</button>
-        <br>
-        <button class='btn btn-primary' style='margin-right: 10px;' ng-click="save()">Save</button>
+        </div> -->
+        <!-- <button class="btn btn-default" type="text" ng-click="contact.languages.push('')">Add another language</button>
+        <br> -->
+        <button class='btn btn-primary' style='margin-right: 10px;' ng-click="save()" ng-disabled="emergencyForm.$invalid">Save</button>
         <button class='btn btn-default' ng-click='cancel()'>Cancel</button>
     </form>
 </div>


### PR DESCRIPTION
In this pull request:
- Dropped languages array in favor of a free-form response for comments and considerations for communication. Given label "Communication considerations / other comments". @keirserrie let me know if there's a better or shorter label that makes sense for this, same with the placeholder text.
- Added line by line validation and form feedback for the user. If a user skips through a required field it will yell at you (gently :smile:)

![image](https://cloud.githubusercontent.com/assets/1919535/7732720/70928912-feef-11e4-9158-cb32dde69593.png)
- Input field widths vary according to the length of the content that will be in it
- Asterisks on required fields. Right now we are requiring Name, Primary Phone Number & Type, Email, and Relationship
- Dropped placeholder text for phone number until we have validation for it, as it confuses the user
- Distinct wording on 'Primary Phone' vs. 'Secondary Phone' vs. 'Tertiary Phone'
- Save button is disabled until form is valid

Screenshots:
Example of invalidness:
![image](https://cloud.githubusercontent.com/assets/1919535/7732799/f83f29b0-feef-11e4-86fc-7e3601ea1d16.png)

Pristine:
![image](https://cloud.githubusercontent.com/assets/1919535/7732813/196d9270-fef0-11e4-808a-461be5cf6bbf.png)

Example of validness:
![image](https://cloud.githubusercontent.com/assets/1919535/7732828/34125ed0-fef0-11e4-9f5d-9871e758835b.png)

Completed Emergency Contact Card:
![image](https://cloud.githubusercontent.com/assets/1919535/7732848/5eb6801c-fef0-11e4-9975-6953f09a538f.png)
