### PR TITLE
MUMPFL-24, 74, 75: Admin Emergency Contact UI and Descriptive Text for LEC

### DIFF
--- a/my-profile-webapp/src/main/webapp/css/my-app.less
+++ b/my-profile-webapp/src/main/webapp/css/my-app.less
@@ -187,3 +187,15 @@ form .form-help {
   margin-top:10px;
   color:#999;
 }
+.description-box {
+  background-color:#ddd;
+  border-radius: 4px;
+  padding:5px 10px;
+  margin-bottom:10px;
+  p {
+    margin:0px;
+  }
+}
+.warn-icon {
+  padding:5px;
+}

--- a/my-profile-webapp/src/main/webapp/my-app/lec/controllers.js
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/controllers.js
@@ -61,11 +61,15 @@ define(['angular'], function(angular) {
       $scope.lookupUser = function(netIdToLookup, index) {
         lecService.searchLocalContactInfo(netIdToLookup).then(function(result){
           $scope.result.people[index].contactInformation = result.data;
-          angular.forEach($scope.result.people[index].contactInformation.addresses, function(value, key, obj){
+          angular.forEach($scope.result.people[index].contactInformation.local.addresses, function(value, key, obj){
             value.edit = false;
             value.readOnly=true;
           });
-          $scope.empty = result.data && result.data.addresses.length === 0;
+          angular.forEach($scope.result.people[index].contactInformation.emergency, function(value, key, obj){
+            value.edit = false;
+            value.readOnly=true;
+          });
+          $scope.empty = result.data && result.data.local.addresses.length === 0;
         }, function(data){
           console.warn("Error looking up person");
           if(data.status === 403) {

--- a/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-info.html
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-info.html
@@ -21,7 +21,7 @@
                     <div ng-if="emergencyInfo.length === 0" class='info-card'>
                         <h1>Emergency Contact</h1>
                         <div class="description-box">
-                          <p>A parent, relative, or other individual to contact in case of an emergency.</p>
+                          <p>A parent, relative, or trusted friend to contact in case of an emergency.</p>
                         </div>
                         <p><i class="fa fa-exclamation-triangle warn-icon"></i>No contact entered yet.</p>
                         <button class='btn btn-primary' ng-click='addEdit()'>Add emergency contact</button>
@@ -30,7 +30,7 @@
                         <div class='info-card emergency-contact'>
                             <h1>Emergency Contact</h1>
                             <div class="description-box">
-                              <p>A parent, relative, or other individual to contact in case of an emergency.</p>
+                              <p>A parent, relative, or trusted friend to contact in case of an emergency.</p>
                             </div>
                             <div class="alert alert-danger" role="alert" ng-if='error && error.length > 0'>{{error}}</div>
                             <emergency></emergency>

--- a/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-info.html
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-info.html
@@ -20,12 +20,18 @@
                     <loading-gif data-object='emergencyInfo' data-empty='noContacts'></loading-gif>
                     <div ng-if="emergencyInfo.length === 0" class='info-card'>
                         <h1>Emergency Contact</h1>
-                        <p>You have no emergency contact information stored.</p>
+                        <div class="description-box">
+                          <p>A parent, relative, or other individual to contact in case of an emergency.</p>
+                        </div>
+                        <p><i class="fa fa-exclamation-triangle warn-icon"></i>No contact entered yet.</p>
                         <button class='btn btn-primary' ng-click='addEdit()'>Add emergency contact</button>
                     </div>
                     <div ng-repeat="contact in emergencyInfo">
                         <div class='info-card emergency-contact'>
                             <h1>Emergency Contact</h1>
+                            <div class="description-box">
+                              <p>A parent, relative, or other individual to contact in case of an emergency.</p>
+                            </div>
                             <div class="alert alert-danger" role="alert" ng-if='error && error.length > 0'>{{error}}</div>
                             <emergency></emergency>
                         </div>
@@ -35,18 +41,20 @@
                     <loading-gif data-object='contactInfo'></loading-gif>
                     <div ng-if="contactInfo.addresses.length === 0" class='info-card'>
                         <h1>My Local Address</h1>
-                        <p>You have no local address information stored.</p>
+                        <div class="description-box">
+                          <p>A physical address where you live or frequently stay during the school year.</p>
+                        </div>
+                        <p><i class="fa fa-exclamation-triangle warn-icon"></i>No address entered yet.</p>
                         <button class='btn btn-primary' ng-click='addEdit()'>Add local address</button>
                     </div>
                     <div ng-repeat="address in contactInfo.addresses">
                         <div class='info-card local-address'>
                             <h1>My Local Address</h1>
+                            <div class="description-box">
+                              <p>A physical address where you live or frequently stay during the school year.</p>
+                            </div>
                             <div class="alert alert-danger" role="alert" ng-if='error && error.length > 0'>{{error}}</div>
                             <lec-address></lec-address>
-                        </div>
-                        <div ng-if="contactInfo.addresses.length === 0" class='info-card'>
-                            <p>You have no local address information stored.</p>
-                            <button class='btn btn-primary' ng-click='addEdit()'>Add local address</button>
                         </div>
                     </div>
                 </div>

--- a/my-profile-webapp/src/main/webapp/my-app/lec/partials/user.html
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/partials/user.html
@@ -19,20 +19,42 @@
   </div>
   <!-- Show the users local contact information or display if not found -->
   <div class="row" ng-show="showingDetails">
-    <div ng-class="{'col-sm-offset-2' : (people.contactInformation.addresses.length === 1),
-                    'col-sm-8' : (people.contactInformation.addresses.length  === 1),
-                    'col-sm-6' : (people.contactInformation.addresses.length > 1)}" 
-         ng-repeat="address in people.contactInformation.addresses">
-      <div class=' info-card'>
+    <div ng-class="{'col-sm-offset-2' : (people.contactInformation.local.addresses.length === 1),
+                    'col-sm-8' : (people.contactInformation.local.addresses.length  === 1),
+                    'col-sm-6' : (people.contactInformation.local.addresses.length > 1)}" 
+         ng-repeat="address in people.contactInformation.local.addresses">
+      <div class='info-card'>
         <p><strong>Local Address</strong></p>
         <address></address>
       </div>
     </div>
-    <div class="noContactInfoFound col-sm-offset-2 col-sm-8" ng-show="!people.contactInformation.addresses.length || 
-                people.contactInformation.addresses.length === 0">
+    
+    <div class="noContactInfoFound col-sm-offset-2 col-sm-8" ng-show="!people.contactInformation.local.addresses.length || 
+                people.contactInformation.local.addresses.length === 0">
       <div class="info-card">
         <span>
           No local contact addresses available for {{people.firstName}} {{people.middleName}} {{people.lastName}}
+        </span>
+      </div>
+    </div>
+  </div>
+  
+  <div class="row" ng-show="showingDetails">
+    <div ng-class="{'col-sm-offset-2' : (people.contactInformation.emergency.length === 1),
+                    'col-sm-8' : (people.contactInformation.emergency.length  === 1),
+                    'col-sm-6' : (people.contactInformation.emergency.length > 1)}" 
+         ng-repeat="contact in people.contactInformation.emergency">
+      <div class='info-card'>
+        <p><strong>Emergency Contact</strong></p>
+        <emergency></emergency>
+      </div>
+    </div>
+    
+    <div class="noContactInfoFound col-sm-offset-2 col-sm-8" ng-show="!people.contactInformation.emergency.length || 
+                people.contactInformation.emergency.length === 0">
+      <div class="info-card">
+        <span>
+          No emergency contacts available for {{people.attributes.displayName[0] ? people.attributes.displayName[0]:people.name}}
         </span>
       </div>
     </div>


### PR DESCRIPTION
Adds emergency contact cards under the local address cards in the admin interface. 
![image](https://cloud.githubusercontent.com/assets/1919535/8625083/17a84914-2702-11e5-961a-b6da63e38842.png)

Adds descriptive text to the cards for emergency contact and local address to inform the user what they are, per @keirserrie's mockups.
![image](https://cloud.githubusercontent.com/assets/1919535/8625098/25dab418-2702-11e5-8b96-870ceed80010.png)

Thanks to @vertein for creating the back end!
