### PR TITLE
MUMPFL-129 Save Bug with Comment Lengths

### DIFF
--- a/my-profile-api/pom.xml
+++ b/my-profile-api/pom.xml
@@ -16,6 +16,14 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fatboyindustrial.gson-jodatime-serialisers</groupId>
+      <artifactId>gson-jodatime-serialisers</artifactId>
+    </dependency>
+    <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/my-profile-api/src/main/java/edu/wisc/my/profile/model/ContactInformation.java
+++ b/my-profile-api/src/main/java/edu/wisc/my/profile/model/ContactInformation.java
@@ -5,6 +5,10 @@ import java.util.List;
 
 import org.joda.time.DateTime;
 
+import com.fatboyindustrial.gsonjodatime.Converters;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
 public class ContactInformation {
   private DateTime lastModified;
   private boolean edit;
@@ -76,5 +80,11 @@ public class ContactInformation {
   }
   public void setEdit(boolean edit) {
     this.edit = edit;
+  }
+  @Override
+  public String toString(){
+      //Converter not needed if we used java 8
+      Gson gson = Converters.registerDateTime(new GsonBuilder()).create();
+      return gson.toJson(this);
   }
 }

--- a/my-profile-api/src/main/java/edu/wisc/my/profile/model/TypeValue.java
+++ b/my-profile-api/src/main/java/edu/wisc/my/profile/model/TypeValue.java
@@ -4,6 +4,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fatboyindustrial.gsonjodatime.Converters;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class TypeValue {
@@ -53,6 +56,13 @@ public class TypeValue {
     result = prime * result + ((type == null) ? 0 : type.hashCode());
     result = prime * result + ((value == null) ? 0 : value.hashCode());
     return result;
+  }
+  
+  @Override
+  public String toString(){
+      //Converter not needed if we used java 8
+      Gson gson = Converters.registerDateTime(new GsonBuilder()).create();
+      return gson.toJson(this);
   }
 
   @Override

--- a/my-profile-webapp/src/main/java/edu/wisc/my/profile/web/EmergencyContactInformationController.java
+++ b/my-profile-webapp/src/main/java/edu/wisc/my/profile/web/EmergencyContactInformationController.java
@@ -49,6 +49,7 @@ public class EmergencyContactInformationController {
         response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
         return ci;
       }
+      logger.info("User {} saved emergency contact information {}", uid, ci);
       return ci;
     } else {
       return ci;

--- a/my-profile-webapp/src/main/java/edu/wisc/my/profile/web/EmergencyPhoneNumberController.java
+++ b/my-profile-webapp/src/main/java/edu/wisc/my/profile/web/EmergencyPhoneNumberController.java
@@ -55,6 +55,7 @@ public class EmergencyPhoneNumberController {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             }
             emPhoneNumberService.setEmergencyPhoneNumbers(uid, (TypeValue[]) phoneNumbers);
+            logger.info("User {} saved phone numbers {}", uid, phoneNumbers);
             response.setStatus(HttpServletResponse.SC_OK);
         } catch (Exception e) {
             logger.error("Issue setting emergency phone number data", e);

--- a/my-profile-webapp/src/main/java/edu/wisc/my/profile/web/LocalContactInformationController.java
+++ b/my-profile-webapp/src/main/java/edu/wisc/my/profile/web/LocalContactInformationController.java
@@ -49,6 +49,7 @@ public class LocalContactInformationController {
         response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
         return ci;
       }
+      logger.info("User {} saved local contact information {}", uid, ci);
       return ci;
     } else {
       return ci;

--- a/my-profile-webapp/src/main/webapp/my-app/lec/partials/address.html
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/partials/address.html
@@ -58,8 +58,8 @@
             <p class="form-help" ng-show="addressForm.postalCode.$invalid && addressForm.postalCode.$touched">ZIP code is required</p>
         </div>
         <div class='form-group'>
-            <label for="comment">More Information <small>({{100 - address.comment.length}} characters left)</small></label>
-            <textarea class="form-control" rows="3" id='comment' ng-model='address.comment' maxlength='100' placeholder="For example, if you are only here on certain days."></textarea>
+            <label for="comment">More Information <small>({{50 - address.comment.length}} characters left)</small></label>
+            <textarea class="form-control" rows="3" id='comment' ng-model='address.comment' maxlength='50' placeholder="For example, if you are only here on certain days."></textarea>
         </div>
         <p>*Required</p>
         <button class='btn btn-primary' style='margin-right: 10px;' ng-click="save()" ng-disabled="addressForm.$invalid">Save</button>

--- a/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency.html
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency.html
@@ -66,8 +66,8 @@
             <p class="form-help" ng-show="emergencyForm.relationship.$invalid && emergencyForm.relationship.$touched">Relationship is required</p>
         </div>
         <div class="form-group">
-            <label for="comments">Comments</label>
-            <textarea class="form-control" id='comments' type='text' ng-model="contact.comments" placeholder="For example, languages spoken or best times to contact"></textarea>
+            <label for="comments">Comments <small>({{50 - contact.comments.length}} characters left)</small></label>
+            <textarea class="form-control" id='comments' type='text' ng-model="contact.comments" maxlength='50' placeholder="For example, languages spoken or best times to contact"></textarea>
         </div>
         <p>*Required</p>
         <button class='btn btn-primary' style='margin-right: 10px;' ng-click="save()" ng-disabled="emergencyForm.$invalid">Save</button>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,8 @@
         <jackson.version>2.2.2</jackson.version>
         <person-directory.version>1.5.2-M1</person-directory.version>
         <spring.security.version>3.2.6.RELEASE</spring.security.version>
+        <gson.version>1.7.1</gson.version>
+        <gson-jodaTime-serializer.version>1.0.0</gson-jodaTime-serializer.version>
     </properties>
 
     <repositories>
@@ -61,7 +63,17 @@
               <artifactId>jackson-datatype-joda</artifactId>
               <version>${jackson.version}</version>
             </dependency>
-
+            
+            <dependency>
+              <groupId>com.google.code.gson</groupId>
+              <artifactId>gson</artifactId>
+              <version>${gson.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>com.fatboyindustrial.gson-jodatime-serialisers</groupId>
+              <artifactId>gson-jodatime-serialisers</artifactId>
+              <version>${gson-jodaTime-serializer.version}</version>
+            </dependency>   
 
             <dependency>
                 <groupId>commons-dbcp</groupId>


### PR DESCRIPTION
Bug - Saving a comment over a certain length resulted in an error. :(

Solution - Update front end to reflect the back end limits and improve logging to capture what users are typing for comments.

Before UI had no character limit for emergency contact and the char limit for local was 100.
Trying to save longer than that would get you a nice error message.
![saveconstraint](https://cloud.githubusercontent.com/assets/5521429/9743379/a4202710-562b-11e5-8b9e-14dd950ea58e.gif)

now!
![image](https://cloud.githubusercontent.com/assets/5521429/9743429/f6f6f3f6-562b-11e5-968f-7f7bec8d070d.png)


