### PR TITLE
MUMPFL-135 Include detail in exceptions

### DIFF
--- a/my-profile-middleware-impl/src/main/java/edu/wisc/my/profile/dao/EmergencyContactMiddlewareDaoImpl.java
+++ b/my-profile-middleware-impl/src/main/java/edu/wisc/my/profile/dao/EmergencyContactMiddlewareDaoImpl.java
@@ -48,7 +48,8 @@ public class EmergencyContactMiddlewareDaoImpl implements EmergencyContactMiddle
       //return saved content
       return emergencyContacts;
     } else {
-      throw new Exception("There was an issue saving the emergency contacts");
+      throw new Exception("Error saving contacts for netid '" + netId + "'; "
+          + "Contacts that failed to save were " + emergencyContacts + ".");
     }
     
   }

--- a/my-profile-middleware-impl/src/main/java/edu/wisc/my/profile/dao/EmergencyPhoneNumberDaoImpl.java
+++ b/my-profile-middleware-impl/src/main/java/edu/wisc/my/profile/dao/EmergencyPhoneNumberDaoImpl.java
@@ -54,7 +54,7 @@ public class EmergencyPhoneNumberDaoImpl implements EmergencyPhoneNumberDao {
           //return saved content
           return phoneNumbers;
         } else {
-          throw new Exception("There was an issue saving the emergency contacts");
+          throw new Exception("There was an issue saving the phone numbers.");
         }
         
       }

--- a/my-profile-middleware-impl/src/main/java/edu/wisc/my/profile/dao/EmergencyPhoneNumberDaoImpl.java
+++ b/my-profile-middleware-impl/src/main/java/edu/wisc/my/profile/dao/EmergencyPhoneNumberDaoImpl.java
@@ -54,7 +54,8 @@ public class EmergencyPhoneNumberDaoImpl implements EmergencyPhoneNumberDao {
           //return saved content
           return phoneNumbers;
         } else {
-          throw new Exception("There was an issue saving the phone numbers.");
+          throw new Exception("Could not save phone numbers for netid '" + netId + "'; "
+              + "The phone numbers were " + phoneNumbers + "'");
         }
         
       }

--- a/my-profile-middleware-impl/src/main/java/edu/wisc/my/profile/dao/LocalContactMiddlewareDaoImpl.java
+++ b/my-profile-middleware-impl/src/main/java/edu/wisc/my/profile/dao/LocalContactMiddlewareDaoImpl.java
@@ -48,7 +48,8 @@ public class LocalContactMiddlewareDaoImpl implements LocalContactMiddlewareDao 
       //  return saved content
       return updatedContactInformation;
     } else {
-      throw new Exception("There was an issue saving the local contact information");
+      throw new Exception("Could not save contact info for netid '" + netId + "'; "
+          + "Contact information was " + updatedContactInformation + ".");
     }
     
     


### PR DESCRIPTION
Add detail about who couldn't save what to `Exceptions` thrown when `DAO` impls fail to save, so that resulting log files become more useful.

Currently:

```
2015-11-10 02:20:33,148 [ajp-nio-127.0.0.1-8009-exec-94] ERROR e.w.m.p.w.EmergencyContactInformationController - Issue setting data
java.lang.Exception: There was an issue saving the emergency contacts
	at edu.wisc.my.profile.dao.EmergencyContactMiddlewareDaoImpl.setData(EmergencyContactMiddlewareDaoImpl.java:51) ~[my-profile-middleware-impl-1.0.0.jar:1.0.0]
	at edu.wisc.my.profile.service.EmergencyContactInformationServiceImpl.setContactInfo(EmergencyContactInformationServiceImpl.java:35) ~[my-profile-middleware-impl-1.0.0.jar:1.0.0]
	at edu.wisc.my.profile.web.EmergencyContactInformationController.setContactInformation(EmergencyContactInformationController.java:46) ~[EmergencyContactInformationController.class:na]
	at sun.reflect.GeneratedMethodAccessor5052.invoke(Unknown Source) ~[na:na]
	at 
```

Cf. [MUMPFL-135](https://jira.doit.wisc.edu/jira/browse/MUMPFL-135).