### PR TITLE
Add travis-ci continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+
+install: true
+script: "mvn package"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
 
 install: true
-script: "mvn package"
+
+# Alas, build only modules that do not require the Oracle jar
+script: "mvn --projects my-profile-api,my-profile-mock-impl,my-profile-local-contact-impl package"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Master branch build status: [![Build Status](https://travis-ci.org/UW-Madison-DoIT/my-profile.svg?branch=master)](https://travis-ci.org/UW-Madison-DoIT/my-profile)

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <packaging>pom</packaging>
     <name>My Profile Parent</name>
     <modules>
+        <!-- When changing modules consider updating .travis.yml -->
         <module>my-profile-webapp</module>
         <module>my-profile-api</module>
         <module>my-profile-mock-impl</module>


### PR DESCRIPTION
Adds `.travis.yml` configuration so that `travis-ci.org` will build each branch and pull request.

Builds only modules that do not require the not-in-public-Maven-repos Oracle database driver .jar.

See also [Travis working on my fork of this repo](https://travis-ci.org/apetro/my-profile).