### PR TITLE
Mw saves funny

### DIFF
--- a/my-profile-api/src/main/java/edu/wisc/my/profile/model/ContactInformation.java
+++ b/my-profile-api/src/main/java/edu/wisc/my/profile/model/ContactInformation.java
@@ -1,6 +1,7 @@
 package edu.wisc.my.profile.model;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -166,7 +167,7 @@ public class ContactInformation {
               append(this.comments).
               append(this.phoneNumbers).
               append(this.emails).
-              append(this.addresses).
+              append(this.addresses!=null? new HashSet<ContactAddress>(this.addresses):this.addresses).
           toHashCode();
   }
   
@@ -183,6 +184,7 @@ public class ContactInformation {
       }
 
       ContactInformation rhs = (ContactInformation) obj;
+      
       return new EqualsBuilder().
               append(this.id, rhs.id).
               append(this.legalName, rhs.legalName).
@@ -191,7 +193,7 @@ public class ContactInformation {
               append(this.comments, rhs.comments).
               append(this.phoneNumbers, rhs.phoneNumbers).
               append(this.emails, rhs.emails).
-              append(this.addresses, rhs.addresses).
+              append(this.addresses!=null? new HashSet<ContactAddress>(this.addresses):this.addresses, rhs.addresses!=null? new HashSet<ContactAddress>(rhs.addresses):rhs.addresses).
           isEquals();
   }
   

--- a/my-profile-api/src/test/java/edu/wisc/my/profile/model/ContactInformationTest.java
+++ b/my-profile-api/src/test/java/edu/wisc/my/profile/model/ContactInformationTest.java
@@ -205,7 +205,9 @@ public class ContactInformationTest {
     
     @Test
     public void testEqualsAddresses(){
-        contact2.setAddresses(Arrays.asList(new ContactAddress()));
+        ContactAddress address = new ContactAddress();
+        address.setCity("Madison");
+        contact2.setAddresses(Arrays.asList(address));
         assertFalse(contact1.equals(contact2));
         assertFalse(contact2.equals(contact1));
     }

--- a/my-profile-middleware-impl/src/main/java/edu/wisc/my/profile/dao/LocalContactMiddlewareDaoImpl.java
+++ b/my-profile-middleware-impl/src/main/java/edu/wisc/my/profile/dao/LocalContactMiddlewareDaoImpl.java
@@ -1,7 +1,11 @@
 package edu.wisc.my.profile.dao;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.sql.DataSource;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import edu.wisc.my.profile.mapper.ContactInformationMapper;
+import edu.wisc.my.profile.model.ContactAddress;
 import edu.wisc.my.profile.model.ContactInformation;
 import edu.wisc.my.profile.model.TypeValue;
 
@@ -48,6 +53,30 @@ public class LocalContactMiddlewareDaoImpl implements LocalContactMiddlewareDao 
         //Fetch results from Middleware
         ContactInformation savedContactInformation = this.getContactInfo(netId);
         //Check to see if MW results are the same as were attempted to save
+        
+        //If we send a null type or comment, MW will add a empty string for us!
+        List<ContactAddress> updatedTypedAddressList = new ArrayList<ContactAddress>();
+        for(ContactAddress address : updatedContactInformation.getAddresses()){
+            if(address.getType()==null){
+                address.setType(StringUtils.EMPTY);
+            }
+            if(address.getComment()==null){
+                address.setComment(StringUtils.EMPTY);
+            }
+            updatedTypedAddressList.add(address);
+        }
+        updatedContactInformation.setAddresses(updatedTypedAddressList);
+        
+        //If we send a empty comment field, MW will set a null for us!
+        List<ContactAddress> updatedCommentAddressList = new ArrayList<ContactAddress>();
+        for(ContactAddress address: savedContactInformation.getAddresses()){
+            if(address.getComment()==null){
+                address.setComment(StringUtils.EMPTY);
+            }
+            updatedCommentAddressList.add(address);
+        }
+        savedContactInformation.setAddresses(updatedCommentAddressList);
+        
         if(!updatedContactInformation.equals(savedContactInformation)){
             throw new Exception("Local contact information was not successfully "
                     + "saved.  Expected to save: "

--- a/my-profile-middleware-impl/src/main/java/edu/wisc/my/profile/dao/LocalContactMiddlewareDaoImpl.java
+++ b/my-profile-middleware-impl/src/main/java/edu/wisc/my/profile/dao/LocalContactMiddlewareDaoImpl.java
@@ -1,6 +1,7 @@
 package edu.wisc.my.profile.dao;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.sql.DataSource;


### PR DESCRIPTION
Before the MW Validation would always fail on initial save. The data would actually save, just when we verified it, it would tell the user that it didn't save.  You can tell that it saved, because when you refreshed the page, your save would appear, and the database confirmed.  This was caused because we pass in values to MW, and MW says, "ha, we will save things differently".

#### Before
![beforealwaysfail](https://cloud.githubusercontent.com/assets/5521429/12852703/f072fada-cbf5-11e5-845e-b72798122dc6.gif)

#### After
![afterlocal](https://cloud.githubusercontent.com/assets/5521429/12853191/52f8917c-cbf8-11e5-9311-93d2cc115996.gif)

Oddly enough, this code catches a newly found Middleware bug
If you have something saved, and you try to delete just your comment, the save then fails.  I'll alert the right people, but I guess, good for us?
![deletecomment](https://cloud.githubusercontent.com/assets/5521429/12856532/043f9acc-cc0b-11e5-9478-ada36853d57b.gif)

