### PR TITLE
Ban Commons Collections 3.2.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,4 +179,25 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <build>
+      <plugins>
+        <plugin>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <executions>
+            <execution>
+              <goals><goal>enforce</goal></goals>
+              <configuration>
+                <rules>
+                  <bannedDependencies>
+                    <excludes>
+                      <exclude>commons-collections:commons-collections:[3.2.1]</exclude>
+                    </excludes>
+                  </bannedDependencies>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
 </project>


### PR DESCRIPTION
So that it cannot enter the build in the future, even as a transitive dependency.
