### PR TITLE
Drop travis.yml to disable travis-ci since false-fails due to code.doit.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: java
-
-install: true
-
-# Alas, build only modules that do not require the Oracle jar
-script: "mvn --projects my-profile-api,my-profile-mock-impl,my-profile-local-contact-impl package"


### PR DESCRIPTION
`code.doit` stopped being publicly visible, but the build depends on it, so build now fails from travis's perspective.

(This also means the build is broken from the perspective of anyone outside of UW-Madison, which impairs thinking about `my-profile` as something that could grow to adoption beyond MyUW...)