### PR TITLE
Add wiscalert message and update design

### DIFF
--- a/my-profile-webapp/src/main/webapp/css/my-app.less
+++ b/my-profile-webapp/src/main/webapp/css/my-app.less
@@ -66,9 +66,68 @@ address {
 
 .description-box {
   p {
-    margin: 0;
     color: #888;
   }
+}
+
+.md-button {
+  &.button-compact {
+    text-transform: none;
+    line-height: 28px;
+    min-width: 60px;
+    min-height: 28px;
+    font-size: 12px;
+    font-weight: 500;
+    margin-left: 0;
+    height: 28px;
+
+    .material-icons {
+      font-size: 20px;
+    }
+  }
+}
+
+.md-button.no-margin-left {
+  margin-left: 0;
+}
+
+.repeat-info {
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #cecece;
+}
+
+.notice-container {
+  border: #cecece 1px solid;
+  border-radius: 6px;
+  margin: 16px 0 6px;
+
+  .notice-description {
+    padding: 8px 16px;
+
+    a.md-subhead {
+      display: block;
+      margin-bottom: 10px
+    }
+
+    p {
+      font-size: 12px;
+      color: #666;
+    }
+  }
+
+  .notice-icon {
+    .material-icons {
+      font-size: 50px;
+      height: 100%;
+      width: 100%;
+      text-align: center;
+    }
+  }
+}
+
+.select-state {
+  margin-bottom: 40px;
 }
 
 /* ------------------------------------ */
@@ -78,17 +137,13 @@ address {
   .md-button {
     margin-top: 0;
   }
-  .buttons-small {
-    .md-button {
-      min-width: 46px;
-    }
-  }
   md-input-container {
-    &.no-margin-bottom {
-      margin-bottom: 0;
-    }
-    &.no-margin-top {
-      margin-top: 0;
+    &.no-spacer:last-child {
+      margin-bottom: 6px;
+
+      div.md-errors-spacer {
+        min-height: 0;
+      }
     }
   }
 }

--- a/my-profile-webapp/src/main/webapp/my-app/lec/controllers.js
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/controllers.js
@@ -97,15 +97,19 @@ define(['angular'], function(angular) {
   
   app.controller('EmergencyPhoneController', ['$localStorage','$rootScope','$scope', 'lecService', function($localStorage, $rootScope, $scope, lecService) {
     //scope functions
-    
+
     $scope.cancel = function() {
       init();
+    };
+
+    $scope.edit = function() {
+      $scope.editMode = true;
     };
     
     $scope.save = function() {
       lecService.saveEmergencyPhoneNumber($scope.emergencyPhoneNumbers.emergencyPhoneNumbers)
         .then(function(result){//success
-           $scope.edit = false;
+          $scope.editMode = false;
         },function(data, status){//error
           $rootScope.alerts.push({ msg: "There was an issue saving your emergency phone, please try again later.", type: 'danger'});
         });
@@ -114,7 +118,7 @@ define(['angular'], function(angular) {
     //local functions
     var init = function() {
       $scope.emergencyPhoneNumbers = [];
-      $scope.edit = false;
+      $scope.editMode = false;
       $scope.empty = false;
       $rootScope.profileLoadingState = $rootScope.profileLoadingState || {};
       $rootScope.profileLoadingState.ephone = true;

--- a/my-profile-webapp/src/main/webapp/my-app/lec/partials/address.html
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/partials/address.html
@@ -1,20 +1,23 @@
 <!-- when simply displaying addresses -->
 <div ng-if="!address.edit || address.edit == false">
-  <div ng-repeat="line in address.addressLines">
-    {{ line }}
-  </div>
-  <div>
-    {{ address.city }}, {{ address.state }} {{ address.postalCode }}
-  </div>
-  <div>
-    {{ address.country }}
-  </div>
-  <p>{{ address.comment }}</p>
-  <p ng-if="address.housing" class="housing-notice">Provided by UW Housing</p>
-  <div layout="row" class="buttons-small">
-    <md-button class="md-accent md-raised" ng-click="addEdit()" ng-hide="address.readOnly && !address.housing" aria-label="add another address">Add another</md-button>
-    <md-button class="md-default md-raised" ng-click="address.edit = true" ng-hide="address.readOnly">Edit</md-button>
-    <md-button class="md-warn md-raised" ng-click="deleteAddress($index)" ng-hide="address.readOnly">Delete</md-button>
+  <div layout="row">
+    <div flex="80" layout="column" layout-align="center start">
+      <span ng-repeat="line in address.addressLines">{{ line }}</span>
+      <span>{{ address.city }}, {{ address.state }} {{ address.postalCode }}</span>
+      <span>{{ address.country }}</span>
+      <p ng-if="address.comment">{{ address.comment }}</p>
+      <p ng-if="address.housing" class="housing-notice">Provided by UW Housing</p>
+    </div>
+    <div flex="20" layout="row" layout-align="end start" class="address-buttons">
+      <md-button class="md-icon-button edit" ng-click="address.edit = true" ng-hide="address.readOnly" aria-label="Edit this address">
+        <md-icon>mode_edit</md-icon>
+        <md-tooltip md-delay="500">Edit</md-tooltip>
+      </md-button>
+      <md-button class="md-icon-button delete" ng-click="deleteAddress($index)" ng-hide="address.readOnly" aria-label="Delete this address">
+        <md-icon>delete</md-icon>
+        <md-tooltip md-delay="500">Delete</md-tooltip>
+      </md-button>
+    </div>
   </div>
 </div>
 <!-- edit/update address form -->
@@ -22,27 +25,27 @@
   <form novalidate name="addressForm">
     <br>
     <!-- input address -->
-    <md-input-container class="md-block no-margin-bottom" ng-repeat="line in address.addressLines | limitTo:5 track by $index">
-      <label>Address Line {{$index + 1}}<span ng-if="$index === 0">*</span></label>
+    <md-input-container class="md-block no-spacer" ng-repeat="line in address.addressLines track by $index">
+      <label>Address Line {{$index + 1}}</label>
       <input ng-if="$index == 0" required ng-model="address.addressLines[$index]" maxlength="100">
       <input ng-if="$index != 0" ng-model="address.addressLines[$index]" maxlength="100">
     </md-input-container>
-    <md-button class="md-default" ng-click="address.addressLines.push('')" ng-if="address.addressLines.length <= 4" aria-label="add another line"><md-icon>add</md-icon> Add line</md-button>
+    <md-button class="md-accent button-compact no-margin-left" ng-click="address.addressLines.push('')" ng-if="address.addressLines.length <= 4" aria-label="add another line"><md-icon>add</md-icon> Add line</md-button>
     <!-- input city -->
-    <md-input-container class="md-block no-margin-bottom">
-      <label>City*</label>
+    <md-input-container class="md-block">
+      <label>City</label>
       <input ng-model="address.city" required maxlength="100">
     </md-input-container>
     <!-- select country -->
-    <md-input-container class="md-block no-margin-top">
-      <label>Country*</label>
+    <md-input-container class="md-block">
+      <label>Country</label>
       <md-select ng-model="address.country" required aria-required="true" ng-change="address.state = ''">
         <md-option ng-repeat="country in countries" ng-value="country.key">{{ country.value }}</md-option>
       </md-select>
     </md-input-container>
     <!-- select state -->
-    <md-input-container class="md-block">
-      <label>State/province/region*</label>
+    <md-input-container class="md-block select-state">
+      <label>State/province/region</label>
       <md-select ng-model="address.state" ng-disabled="!address.country || (states | filter:{ counter: address.country }).length === 0">
         <md-option ng-if="!address.country" value="">Select country first</md-option>
         <md-option ng-if="address.country && (states | filter:{country: address.country}).length === 0" value="">No states/provinces/regions for this country</md-option>
@@ -51,7 +54,7 @@
     </md-input-container>
     <!-- input zip -->
     <md-input-container class="md-block">
-      <label>Zip*</label>
+      <label>Zip</label>
       <input ng-model="address.postalCode" required maxlength="10">
     </md-input-container>
     <!-- input comments -->
@@ -59,9 +62,7 @@
       <label>Mode information</label>
       <textarea ng-model="address.comment" md-maxlength="50" rows="3" md-select-on-focus placeholder="Ex. I am only here Monday and Wednesday"></textarea>
     </md-input-container>
-
-    <p>*Required</p>
-    <md-button class="md-raised md-accent" ng-click="save()" ng-disabled="addressForm.$invalid">Save</md-button>
+    <md-button class="md-raised md-accent no-margin-left" ng-click="save()" ng-disabled="addressForm.$invalid">Save</md-button>
     <md-button class="md-default md-raised" ng-click="cancel()">Cancel</md-button>
-    </form>
+  </form>
 </div>

--- a/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-info.html
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-info.html
@@ -49,7 +49,7 @@
       <md-card ng-if="contactInfo.addresses.length === 0" class="contact-info-card">
         <md-card-title>
           <md-card-title-text>
-            <h2 class="md-headline">My local address</h2>
+            <h2 class="md-headline">Local address</h2>
           </md-card-title-text>
         </md-card-title>
         <md-card-content>
@@ -60,11 +60,11 @@
           <md-button class="md-accent md-raised" ng-click="addEdit()">Add local address</md-button>
         </md-card-content>
       </md-card>
-      <!-- repeat for each address -->
-      <md-card ng-repeat="address in contactInfo.addresses" class="contact-info-card">
+      <!-- addresses exist -->
+      <md-card ng-if="contactInfo.addresses.length != 0" class="contact-info-card">
         <md-card-title>
           <md-card-title-text>
-            <h2 class="md-headline">My local address</h2>
+            <h2 class="md-headline">Local address</h2>
           </md-card-title-text>
         </md-card-title>
         <md-card-content>
@@ -72,7 +72,13 @@
             <p>A physical address where you live or frequently stay during the school year.</p>
           </div>
           <div class="alert" role="alert" ng-if="error && error.length > 0">{{ error }}</div>
-          <lec-address></lec-address>
+          <!-- repeat for each address -->
+          <div class="repeat-info" ng-repeat="address in contactInfo.addresses">
+            <lec-address></lec-address>
+          </div>
+          <div layout="row">
+            <md-button class="md-accent md-raised no-margin-left" ng-click="addEdit()" aria-label="add another address">Add another</md-button>
+          </div>
         </md-card-content>
       </md-card>
     </div>
@@ -91,11 +97,11 @@
             <p>A parent, relative, or trusted friend to contact in case of an emergency.</p>
           </div>
           <p><md-icon class="md-warn">warning</md-icon> No contact entered yet.</p>
-          <md-button class="md-accent md-raised" ng-click="addEdit()">Add emergency contact</md-button>
+          <md-button class="md-accent md-raised no-margin-left" ng-click="addEdit()">Add emergency contact</md-button>
         </md-card-content>
       </md-card>
-      <!-- repeat for each emergency contact -->
-      <md-card ng-repeat="contact in emergencyInfo" class="contact-info-card" flex>
+      <!-- entries exist -->
+      <md-card ng-if="emergencyInfo.length != 0" class="contact-info-card" flex>
         <md-card-title>
           <md-card-title-text>
             <h2 class="md-headline">Emergency contact</h2>
@@ -106,7 +112,13 @@
             <p>A parent, relative, or trusted friend to contact in case of an emergency.</p>
           </div>
           <div class="alert" role="alert" ng-if="error && error.length > 0">{{ error }}</div>
-          <emergency></emergency>
+          <!-- repeat for each emergency contact -->
+          <div class="repeat-info" ng-repeat="contact in emergencyInfo">
+            <emergency></emergency>
+          </div>
+          <div layout="row">
+            <md-button class="md-accent md-raised no-margin-left" ng-click="addEdit()" aria-label="add another emergency contact">Add another</md-button>
+          </div>
         </md-card-content>
       </md-card>
     </div>

--- a/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-phone.html
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-phone.html
@@ -53,10 +53,10 @@
         </div>
         <div class="notice-description" flex-gt-xs="80">
           <a class="md-subhead" href="https://my.wisc.edu/portal/p/wisc-alerts-text-messaging/render.uP" rel="nofollow noreferrer" target="_blank">WiscAlerts</a>
-          <p>By saving your emergency phone number, you will be automatically signed up for WiscAlerts, UW-Madison's emergency notification system.</p>
+          <p>This phone number will be automatically registered to receive WiscAlerts, UW-Madison's emergency notifications.</p>
           <p>
-            For more information, see the <a href="https://kb.wisc.edu/page.php?id=13839">WiscAlerts FAQ</a>.
-            You can op-out of receiving emergency alerts in the <a href="https://my.wisc.edu/portal/p/wisc-alerts-text-messaging/render.uP">WiscAlerts app</a>.
+            For more information, see the <a href="https://kb.wisc.edu/page.php?id=13839" target="_blank" rel="noreferrer nofollow">WiscAlerts FAQ</a>.
+            You can op-out of receiving emergency alerts in the <a href="https://my.wisc.edu/portal/p/wisc-alerts-text-messaging/render.uP" target="_blank" rel="noreferrer nofollow">WiscAlerts app</a>.
           </p>
         </div>
       </div>

--- a/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-phone.html
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-phone.html
@@ -1,49 +1,68 @@
 <div ng-controller="EmergencyPhoneController as EmergencyPhoneCtrl">
-<loading-gif data-object="emergencyPhoneNumbers" data-reuse="true"></loading-gif>
-<md-card ng-show="empty || emergencyPhoneNumbers.emergencyPhoneNumbers.length>0" class="contact-info-card" flex>
-  <md-card-title>
-    <md-card-title-text>
-      <h2 class="md-headline">My phone number</h2>
-    </md-card-title-text>
-  </md-card-title>
-  <md-card-content>
-    <div class="description-box">
-      <p>A number where you can be reached in an emergency.</p>
-    </div>
-    <p ng-if="emergencyPhoneNumbers.emergencyPhoneNumbers.length === 0 && !edit" >
-      <md-icon>warning</md-icon> No phone number entered yet.
-    </p>
-    <p ng-if="!edit && emergencyPhoneNumbers.emergencyPhoneNumbers.length">
-      {{emergencyPhoneNumbers.emergencyPhoneNumbers[0].value}} ({{emergencyPhoneNumbers.emergencyPhoneNumbers[0].type}})
-    </p>
-    <div ng-hide="!edit">
-      <form novalidate name="emergencyPhoneNumberForm">
-        <br>
-        <md-input-container class="md-block no-margin-bottom" flex-gt-sm>
-          <label>Phone number*</label>
-          <input type="tel" required aria-required="true" ng-pattern=/^([a-zA-Z0-9\s!-.]{1,30})$/ ng-maxlength="30" ng-model="emergencyPhoneNumbers.emergencyPhoneNumbers[0].value">
-        </md-input-container>
-        <md-input-container class="md-block no-margin-top" flex-gt-sm>
-          <label>Type*</label>
-          <md-select required aria-required="true" ng-model="emergencyPhoneNumbers.emergencyPhoneNumbers[0].type">
-            <md-option value="mobile">Mobile</md-option>
-            <md-option value="home">Home</md-option>
-            <md-option value="work">Work</md-option>
-          </md-select>
-        </md-input-container>
-        <p>*Required</p>
-        <md-button class="md-accent md-raised" aria-label="Save phone number" ng-click="save()" ng-disabled="emergencyPhoneNumberForm.$invalid">Save</md-button>
-        <md-button class="md-default md-raised" aria-label="Cancel" ng-click='cancel()'>Cancel</md-button>
-      </form>
-    </div>
-    <div ng-show="!edit" ng-click="edit = true" ng-switch="emergencyPhoneNumbers.emergencyPhoneNumbers.length">
-      <div ng-switch-when="0">
-        <md-button aria-label="Add phone number" class="md-accent md-raised">Add phone number</md-button>
+  <loading-gif data-object="emergencyPhoneNumbers" data-reuse="true"></loading-gif>
+  <md-card ng-show="empty || emergencyPhoneNumbers.emergencyPhoneNumbers.length>0" class="contact-info-card" flex>
+    <md-card-title>
+      <md-card-title-text>
+        <h2 class="md-headline">Phone number</h2>
+      </md-card-title-text>
+    </md-card-title>
+    <md-card-content>
+      <div class="description-box">
+        <p>A number where you can be reached in an emergency.</p>
       </div>
-      <div ng-switch-default>
-        <md-button aria-label="Update phone number" class="md-default md-raised">Update phone number</md-button>
+      <!-- Empty state -->
+      <div ng-if="emergencyPhoneNumbers.emergencyPhoneNumbers.length === 0 && !editMode" >
+        <p><md-icon>warning</md-icon> No phone number entered yet.</p>
+        <md-button aria-label="Add phone number" class="md-accent md-raised no-margin-left" ng-click="edit()">Add phone number</md-button>
       </div>
-    </div>
-  </md-card-content>
-</md-card>
+      <!-- Non-empty -->
+      <div ng-if="!editMode && emergencyPhoneNumbers.emergencyPhoneNumbers.length" layout="row" layout-align="space-between center">
+        <span class="md-subhead" flex="80">
+          {{ emergencyPhoneNumbers.emergencyPhoneNumbers[0].value}} ({{emergencyPhoneNumbers.emergencyPhoneNumbers[0].type }})
+        </span>
+        <md-button class="md-icon-button" aria-label="edit phone number" ng-click="edit()">
+          <md-icon>mode_edit</md-icon>
+          <md-tooltip md-delay="500">Edit</md-tooltip>
+        </md-button>
+      </div>
+      <!-- Phone number form -->
+      <div ng-hide="!editMode">
+        <form novalidate name="emergencyPhoneNumberForm">
+          <br>
+          <md-input-container class="md-block" flex-gt-sm>
+            <label>Phone number*</label>
+            <input type="tel" required aria-required="true" ng-pattern=/^([a-zA-Z0-9\s!-.]{1,30})$/ ng-maxlength="30" ng-model="emergencyPhoneNumbers.emergencyPhoneNumbers[0].value">
+          </md-input-container>
+          <md-input-container class="md-block" flex-gt-sm>
+            <label>Type*</label>
+            <md-select required aria-required="true" ng-model="emergencyPhoneNumbers.emergencyPhoneNumbers[0].type">
+              <md-option value="mobile">Mobile</md-option>
+              <md-option value="home">Home</md-option>
+              <md-option value="work">Work</md-option>
+            </md-select>
+          </md-input-container>
+          <p>*Required</p>
+          <md-button class="md-accent md-raised no-margin-left" aria-label="Save phone number" ng-click="save()" ng-disabled="emergencyPhoneNumberForm.$invalid">Save</md-button>
+          <md-button class="md-default md-raised" aria-label="Cancel" ng-click='cancel()'>Cancel</md-button>
+        </form>
+      </div>
+      <!-- WiscAlert notice -->
+      <div class="notice-container" layout="row" layout-align="start center">
+        <div class="notice-icon" flex-gt-xs="20" hide-xs>
+          <md-icon>announcement</md-icon>
+        </div>
+        <div class="notice-description" flex-gt-xs="80">
+          <a class="md-subhead" href="https://my.wisc.edu/portal/p/wisc-alerts-text-messaging/render.uP" rel="nofollow noreferrer" target="_blank">Sign up for WiscAlerts</a>
+          <p>
+            WiscAlerts is the name for UW-Madison's emergency notification system. In the event of a campus emergency, students, faculty and staff will receive timely information
+            and updates about a situation and steps you can take to stay safe.
+          </p>
+          <p>
+            Go to the <a href="https://my.wisc.edu/portal/p/wisc-alerts-text-messaging/render.uP">WiscAlerts app</a> to sign up.
+            If you don't want to sign up now, you can easily find the app later by searching for "WiscAlerts" in MyUW.
+          </p>
+        </div>
+      </div>
+    </md-card-content>
+  </md-card>
 </div>

--- a/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-phone.html
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-phone.html
@@ -49,17 +49,14 @@
       <!-- WiscAlert notice -->
       <div class="notice-container" layout="row" layout-align="start center">
         <div class="notice-icon" flex-gt-xs="20" hide-xs>
-          <md-icon>announcement</md-icon>
+          <md-icon>info</md-icon>
         </div>
         <div class="notice-description" flex-gt-xs="80">
-          <a class="md-subhead" href="https://my.wisc.edu/portal/p/wisc-alerts-text-messaging/render.uP" rel="nofollow noreferrer" target="_blank">Sign up for WiscAlerts</a>
+          <a class="md-subhead" href="https://my.wisc.edu/portal/p/wisc-alerts-text-messaging/render.uP" rel="nofollow noreferrer" target="_blank">WiscAlerts</a>
+          <p>By saving your emergency phone number, you will be automatically signed up for WiscAlerts, UW-Madison's emergency notification system.</p>
           <p>
-            WiscAlerts is the name for UW-Madison's emergency notification system. In the event of a campus emergency, students, faculty and staff will receive timely information
-            and updates about a situation and steps you can take to stay safe.
-          </p>
-          <p>
-            Go to the <a href="https://my.wisc.edu/portal/p/wisc-alerts-text-messaging/render.uP">WiscAlerts app</a> to sign up.
-            If you don't want to sign up now, you can easily find the app later by searching for "WiscAlerts" in MyUW.
+            For more information, see the <a href="https://kb.wisc.edu/page.php?id=13839">WiscAlerts FAQ</a>.
+            You can op-out of receiving emergency alerts in the <a href="https://my.wisc.edu/portal/p/wisc-alerts-text-messaging/render.uP">WiscAlerts app</a>.
           </p>
         </div>
       </div>

--- a/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency.html
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency.html
@@ -1,39 +1,47 @@
 <!-- display emergency contacts -->
 <div ng-if="!contact.edit || contact.edit == false">
-  <p>{{ contact.preferredName }}</p>
-  <div ng-repeat="phone in contact.phoneNumbers">
-    <p ng-if="phone.value && phone.type">
-      <span ng-if="$index === 0">Primary phone: </span>
-      <span>{{ phone.value }} ({{ phone.type }})</span>
-    </p>
-  </div>
-  <p>{{ contact.emails[0].value }}</p>
-  <p ng-if="contact.relationship">Relationship: {{ contact.relationship }}</p>
-  <p ng-if="contact.comments">Comments: {{ contact.comments }}</p>
-  <div layout="row" ng-hide="contact.readOnly" class="buttons-small">
-    <md-button class="md-accent md-raised" ng-click="addEdit()" aria-label="add another emergency contact">Add another</md-button>
-    <md-button class="md-default md-raised" ng-click="contact.edit = true" aria-label="edit emergency contact">Edit</md-button>
-    <md-button class="md-warn md-raised" ng-click="deleteContact($index)" aria-label="delete emergency contact">Delete</md-button>
+  <div layout="row">
+    <div flex="80" layout="column" layout-align="center start">
+      <span class="md-subhead">{{ contact.preferredName }}</span>
+      <div ng-repeat="phone in contact.phoneNumbers">
+        <div ng-if="phone.value && phone.type">
+          <span ng-if="$index === 0">Primary phone: </span><span>{{ phone.value }} ({{ phone.type }})</span>
+        </div>
+      </div>
+      <span>{{ contact.emails[0].value }}</span>
+      <span ng-if="contact.relationship">Relationship: {{ contact.relationship }}</span>
+      <span ng-if="contact.comments">Comments: {{ contact.comments }}</span>
+    </div>
+    <div flex="20" layout="row" layout-align="end start" class="action-buttons">
+      <md-button class="md-icon-button edit" ng-click="contact.edit = true" aria-label="edit emergency contact" ng-hide="contact.readOnly">
+        <md-icon>mode_edit</md-icon>
+        <md-tooltip md-delay="500">Edit</md-tooltip>
+      </md-button>
+      <md-button class="md-icon-button delete" ng-click="deleteContact($index)" aria-label="delete emergency contact" ng-hide="contact.readOnly">
+        <md-icon>delete</md-icon>
+        <md-tooltip md-delay="500">Delete</md-tooltip>
+      </md-button>
+    </div>
   </div>
 </div>
 <!-- edit emergency contacts -->
 <div ng-if="contact.edit">
   <form name="emergencyForm" novalidate class="emergency-info">
     <br>
-    <md-input-container class="md-block no-margin-bottom">
-      <label>Name*</label>
+    <md-input-container class="md-block">
+      <label>Name</label>
       <input ng-model="contact.preferredName" required aria-required="true" name="name">
     </md-input-container>
     <div ng-repeat="phone in contact.phoneNumbers | limitTo:3 track by $index" layout-gt-xs="row">
       <div flex="90">
-        <md-input-container class="md-block no-margin-bottom no-margin-top" flex-gt-sm>
-          <label ng-if="$index === 0">Primary phone*</label>
+        <md-input-container class="md-block" flex-gt-sm>
+          <label ng-if="$index === 0">Primary phone</label>
           <input ng-if="$index === 0" type="tel" name="phone{{$index}}" ng-required="$index === 0" ng-pattern=/^([a-zA-Z0-9\s!-.]{1,30})$/ ng-model="contact.phoneNumbers[$index].value">
           <label ng-if="$index !== 0">Other phone</label>
           <input ng-if="$index !== 0" type="tel" name="phone{{$index}}" ng-pattern=/^([a-zA-Z0-9\s!-.]{1,30})$/ ng-model="contact.phoneNumbers[$index].value">
         </md-input-container>
-        <md-input-container class="md-block no-margin-top" flex-gt-sm>
-          <label ng-if="$index === 0">Type*</label>
+        <md-input-container class="md-block no-spacer" flex-gt-sm>
+          <label ng-if="$index === 0">Type</label>
           <label ng-if="$index !== 0">Type</label>
           <md-select name="phoneType{{$index}}" ng-required="$index === 0" ng-model="contact.phoneNumbers[$index].type" aria-label="phone type">
             <md-option value="mobile">Mobile</md-option>
@@ -44,16 +52,18 @@
         </md-input-container>
       </div>
       <div flex="10">
-        <md-button aria-label="delete phone number" class="md-icon-button" ng-click="contact.phoneNumbers.splice($index, 1)" ng-if="$index !== 0"></md-button>
+        <md-button aria-label="delete phone number" class="md-icon-button" ng-click="contact.phoneNumbers.splice($index, 1)" ng-if="$index !== 0">
+          <md-icon>delete</md-icon>
+        </md-button>
       </div>
     </div>
-    <md-button class="md-default md-raised" ng-click="contact.phoneNumbers.push({ 'type' : '', value : ''})" ng-if="contact.phoneNumbers.length < 3" aria-label="add another phone number"><md-icon>add</md-icon> Add another phone</md-button>
-    <md-input-container class="md-block no-margin-bottom">
-      <label>Email*</label>
+    <md-button class="md-accent button-compact no-margin-left"  ng-click="contact.phoneNumbers.push({ 'type' : '', value : ''})" ng-if="contact.phoneNumbers.length < 3" aria-label="add another phone number"><md-icon>add</md-icon> Add another number</md-button>
+    <md-input-container class="md-block">
+      <label>Email</label>
       <input name="email" required ng-model="contact.emails[0].value">
     </md-input-container>
-    <md-input-container class="md-block no-margin-top">
-      <label>Relationship*</label>
+    <md-input-container class="md-block">
+      <label>Relationship</label>
       <md-select ng-model="contact.relationship" name="relationship" required>
         <md-option ng-repeat="item in relationshipOptions" ng-value="item.key" ng-attr-selected="{{isSelection(contact.relationship, item.key)}}">{{ item.value }}</md-option>
       </md-select>
@@ -63,8 +73,7 @@
       <label>Comments</label>
       <textarea ng-model="contact.comments" md-maxlength="50" placeholder="Ex. First language is Spanish"></textarea>
     </md-input-container>
-    <p>*Required</p>
-    <md-button class="md-accent md-raised" ng-click="save()" ng-disabled="emergencyForm.$invalid">Save</md-button>
-    <md-button class="md-default md-raised" ng-click='cancel()'>Cancel</md-button>
+    <md-button class="md-accent md-raised no-margin-left" ng-click="save()" ng-disabled="emergencyForm.$invalid">Save</md-button>
+    <md-button class="md-default md-raised" ng-click="cancel()">Cancel</md-button>
     </form>
 </div>

--- a/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency.html
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency.html
@@ -41,8 +41,7 @@
           <input ng-if="$index !== 0" type="tel" name="phone{{$index}}" ng-pattern=/^([a-zA-Z0-9\s!-.]{1,30})$/ ng-model="contact.phoneNumbers[$index].value">
         </md-input-container>
         <md-input-container class="md-block no-spacer" flex-gt-sm>
-          <label ng-if="$index === 0">Type</label>
-          <label ng-if="$index !== 0">Type</label>
+          <label>Type</label>
           <md-select name="phoneType{{$index}}" ng-required="$index === 0" ng-model="contact.phoneNumbers[$index].type" aria-label="phone type">
             <md-option value="mobile">Mobile</md-option>
             <md-option value="home">Home</md-option>


### PR DESCRIPTION
[MUMPFL-153](https://jira.doit.wisc.edu/jira/browse/MUMPFL-153): "As a student accessing Local/Emergency Contact, I would like to be reminded of the opportunity to register my cell phone for WiscAlerts, so that I can understand the relationship between these registrations and successfully enable the university to contact me in an emergency."

**In this PR**:
- Add message directing people to the WiscAlert portlet to opt-in
- Cosmetic updates
    - Normal spacing in material forms
    - Repeat blocks of info instead of entire cards
    - Icon buttons with tooltips for edit/delete

### Screenshots
(*note: the WiscAlert message in the first screenshot is from a previous commit*)
![screen shot 2017-08-29 at 1 23 00 pm](https://user-images.githubusercontent.com/5818702/29837759-b8a4855c-8cbe-11e7-9717-168210079836.png)
<img width="467" alt="screen shot 2017-08-31 at 9 39 29 am" src="https://user-images.githubusercontent.com/5818702/29929236-93fcce76-8e30-11e7-82dd-f8e6077e9cfd.png">
