### PR TITLE
MUMPFL-157 server-side controllers responding with the last saved object on set

### DIFF
--- a/my-profile-api/pom.xml
+++ b/my-profile-api/pom.xml
@@ -35,5 +35,9 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/my-profile-api/src/main/java/edu/wisc/my/profile/log/MaskedLoggable.java
+++ b/my-profile-api/src/main/java/edu/wisc/my/profile/log/MaskedLoggable.java
@@ -1,0 +1,10 @@
+package edu.wisc.my.profile.log;
+
+public interface MaskedLoggable {
+  /**
+   * Use for logging when masking values is needed.
+   * Data that is considered sensitive will be masked.
+   * @return a JSON representation with the value data masked, useful for logging
+   */
+  public String toStringForLogging();
+}

--- a/my-profile-api/src/main/java/edu/wisc/my/profile/log/MaskedLoggables.java
+++ b/my-profile-api/src/main/java/edu/wisc/my/profile/log/MaskedLoggables.java
@@ -1,0 +1,34 @@
+package edu.wisc.my.profile.log;
+
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import org.apache.commons.lang3.StringUtils;
+
+public class MaskedLoggables {
+  private MaskedLoggables() {}
+  public static String toStringForLogging(MaskedLoggable toLog) {
+    String result = "";
+    if (null != toLog) {
+      result = toLog.toStringForLogging();
+    }
+    return result;
+  }
+  public static String toStringForLogging(MaskedLoggable... toLog) {
+    StringBuilder result = new StringBuilder();
+    result.append("[");
+    if (null != toLog) {
+      result.append(StringUtils.join(FluentIterable.from(toLog).transform(new Function<MaskedLoggable, String>() {
+        @Override
+        public String apply(MaskedLoggable element) {
+          String result = null;
+          if (null != element) {
+            result = element.toStringForLogging();
+          }
+          return result;
+        }
+      }), ", "));
+    }
+    result.append("]");
+    return result.toString();
+  }
+}

--- a/my-profile-api/src/main/java/edu/wisc/my/profile/model/ContactAddress.java
+++ b/my-profile-api/src/main/java/edu/wisc/my/profile/model/ContactAddress.java
@@ -12,9 +12,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fatboyindustrial.gsonjodatime.Converters;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import edu.wisc.my.profile.log.MaskedLoggable;
 
 @JsonIgnoreProperties("$$hashKey")
-public class ContactAddress {
+public class ContactAddress implements MaskedLoggable {
   private String type;
   private List<String> addressLines = new ArrayList<String>();
   private String city;
@@ -99,6 +100,7 @@ public class ContactAddress {
    * type, the address information, and user inputed comments
    * @return a JSON representation with the value data masked, useful for logging
    */
+  @Override
   public String toStringForLogging(){
       StringBuilder builder = new StringBuilder();
       builder.append("{")

--- a/my-profile-api/src/main/java/edu/wisc/my/profile/model/ContactInformation.java
+++ b/my-profile-api/src/main/java/edu/wisc/my/profile/model/ContactInformation.java
@@ -12,8 +12,9 @@ import org.joda.time.DateTime;
 import com.fatboyindustrial.gsonjodatime.Converters;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import edu.wisc.my.profile.log.MaskedLoggable;
 
-public class ContactInformation {
+public class ContactInformation implements MaskedLoggable {
   private DateTime lastModified;
   private boolean edit;
   private String id;
@@ -95,14 +96,14 @@ public class ContactInformation {
       Gson gson = Converters.registerDateTime(new GsonBuilder()).create();
       return gson.toJson(this);
   }
-  
-  
+
   /**
    * Use for logging when masking values is needed.
    * Data that is considered sensitive will be masked.  Fields that are masked are
    * preferredName, relationship, user inputed comments, phone numbers, emails, and address information
    * @return a JSON representation with the value data masked, useful for logging
    */
+  @Override
   public String toStringForLogging(){
       StringBuilder builder = new StringBuilder();
       builder.append("{")

--- a/my-profile-api/src/main/java/edu/wisc/my/profile/model/TypeValue.java
+++ b/my-profile-api/src/main/java/edu/wisc/my/profile/model/TypeValue.java
@@ -7,9 +7,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fatboyindustrial.gsonjodatime.Converters;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import edu.wisc.my.profile.log.MaskedLoggable;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
-public class TypeValue {
+public class TypeValue implements MaskedLoggable {
   
   public TypeValue() {
     
@@ -69,6 +70,7 @@ public class TypeValue {
    * Use for logging when masking values is needed.  Value information is masked.
    * @return a JSON representation with the value data masked
    */
+  @Override
   public String toStringForLogging(){
       StringBuilder builder = new StringBuilder()
       .append("{\"type\":\"")

--- a/my-profile-webapp/pom.xml
+++ b/my-profile-webapp/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>1.7.1</version>
         </dependency>
 
         <dependency>

--- a/my-profile-webapp/pom.xml
+++ b/my-profile-webapp/pom.xml
@@ -11,8 +11,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>edu.wisc.my.apps</groupId>
-            <artifactId>uw-frame</artifactId>
+            <groupId>org.apereo.uportal</groupId>
+            <artifactId>uportal-app-framework</artifactId>
             <type>war</type>
         </dependency>
         <dependency>

--- a/my-profile-webapp/src/main/java/edu/wisc/my/profile/web/EmergencyContactInformationController.java
+++ b/my-profile-webapp/src/main/java/edu/wisc/my/profile/web/EmergencyContactInformationController.java
@@ -1,5 +1,6 @@
 package edu.wisc.my.profile.web;
 
+import edu.wisc.my.profile.log.MaskedLoggables;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -36,36 +37,26 @@ public class EmergencyContactInformationController {
   }
   
   @RequestMapping(method = RequestMethod.POST, value="/set")
-  public @ResponseBody ContactInformation[] setContactInformation(HttpServletRequest request, 
-                                                                  @RequestBody ContactInformation[] ci,
-                                                                  HttpServletResponse response) {
+  public @ResponseBody ContactInformation[] setContactInformation(
+          HttpServletRequest request, 
+          @RequestBody ContactInformation[] ci,
+          HttpServletResponse response) {
     final String uid = request.getHeader("uid");
-    //TODO validate
-    if(StringUtils.isNotBlank(uid)) {
-      try {
-        ci = service.setContactInfo(uid, ci);
-      } catch (Exception e) {
-          StringBuilder builder = new StringBuilder()
-          .append("[");
-          int ciCounter = 0;
-          for(ContactInformation contactInformation: ci){
-              if(ciCounter>0){
-                  builder.append(", ");
-              }
-              builder.append(contactInformation.toStringForLogging());
-              ciCounter++;
-          }
-          builder.append("]");
-          String maskedData = builder.toString();
-          logger.error("Issue while user {} attempted to save {}", uid, maskedData, e);
-          response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
-          return ci;
-      }
-      logger.info("User {} saved Emergency Contact Information successfully", uid);
-    }else{
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    
+    if (StringUtils.isBlank(uid)) {
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      return null;
     }
-    return ci;
+    
+    try {
+      service.setContactInfo(uid, ci);
+      logger.info("User {} saved Emergency Contact Information successfully", uid);
+    } catch (Exception e) {
+        String maskedData = MaskedLoggables.toStringForLogging(ci);
+        logger.error("Issue while user {} attempted to save {}", uid, maskedData, e);
+        response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    }
+    return service.getContactInfo(uid);
   }
 
 }

--- a/my-profile-webapp/src/main/java/edu/wisc/my/profile/web/EmergencyPhoneNumberController.java
+++ b/my-profile-webapp/src/main/java/edu/wisc/my/profile/web/EmergencyPhoneNumberController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.google.gson.Gson;
+import edu.wisc.my.profile.log.MaskedLoggables;
 
 import edu.wisc.my.profile.model.TypeValue;
 import edu.wisc.my.profile.service.EmergencyPhoneNumberService;
@@ -28,51 +29,45 @@ public class EmergencyPhoneNumberController {
     private EmergencyPhoneNumberService emPhoneNumberService;
     
     @RequestMapping(method = RequestMethod.GET, value="/get.json")
-    public @ResponseBody void getPhoneNumber(HttpServletRequest request, HttpServletResponse response){
-        try {
-            String username = request.getHeader("uid");
-            if(StringUtils.isBlank(username)){
-                logger.warn("User hit get emergency phone number service w/o username set");
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            }
-            TypeValue[] phoneNumbers =  emPhoneNumberService.getEmergencyPhoneNumbers(username);
-            Gson gson = new Gson();
-            response.getWriter().write("{\"emergencyPhoneNumbers\":"+gson.toJson(phoneNumbers)+"}");
-            response.setContentType("application/json");
-            response.setStatus(HttpServletResponse.SC_OK);
-        } catch (Exception e) {
-            logger.error("Issue happened during lookup", e);
-            response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
-        }
+    public @ResponseBody TypeValue[] getPhoneNumber(HttpServletRequest request, HttpServletResponse response){
+      TypeValue[] phoneNumbers = null;
+      String username = request.getHeader("uid");
+      
+      if(StringUtils.isBlank(username)){
+          logger.warn("User hit get emergency phone number service w/o username set");
+          response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+          return null;
+      }
+      
+      try {
+          phoneNumbers = emPhoneNumberService.getEmergencyPhoneNumbers(username);
+      } catch (Exception e) {
+          logger.error("Issue happened during lookup", e);
+          response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+      }
+      return phoneNumbers;
     }
     
     @RequestMapping(method = RequestMethod.POST, value="/set")
-    public @ResponseBody void setPhoneNumber(HttpServletRequest request, @RequestBody TypeValue[] phoneNumbers, HttpServletResponse response){
+    public @ResponseBody TypeValue[] setPhoneNumber(HttpServletRequest request, @RequestBody TypeValue[] phoneNumbers, HttpServletResponse response){
         final String uid = request.getHeader("uid");
+        
+        if(StringUtils.isBlank(uid)){
+            logger.warn("User hit get emergency phone number service w/o username set");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return null;
+        }
+        
         try {
-            if(StringUtils.isBlank(uid)){
-                logger.warn("User hit get emergency phone number service w/o username set");
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            }
             emPhoneNumberService.setEmergencyPhoneNumbers(uid, (TypeValue[]) phoneNumbers);
             logger.info("User {} saved phone numbers successfully", uid);
-            response.setStatus(HttpServletResponse.SC_OK);
         } catch (Exception e) {
-            StringBuilder builder = new StringBuilder()
-            .append("[");
-            int phoneNumberCounter = 0;
-            for(TypeValue phoneNumber: phoneNumbers){
-                if(phoneNumberCounter>0){
-                    builder.append(", ");
-                }
-                builder.append(phoneNumber.toStringForLogging());
-                phoneNumberCounter++;
-            }
-            builder.append("]");
-            String maskedData = builder.toString();
+            String maskedData = MaskedLoggables.toStringForLogging(phoneNumbers);
             logger.error("Issue while user {} attempted to save {}", uid, maskedData, e);
             response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
         }
+        
+        return emPhoneNumberService.getEmergencyPhoneNumbers(uid);
     }
     
 }

--- a/my-profile-webapp/src/main/java/edu/wisc/my/profile/web/LocalContactInformationController.java
+++ b/my-profile-webapp/src/main/java/edu/wisc/my/profile/web/LocalContactInformationController.java
@@ -1,5 +1,6 @@
 package edu.wisc.my.profile.web;
 
+import edu.wisc.my.profile.log.MaskedLoggables;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -36,24 +37,26 @@ public class LocalContactInformationController {
   }
   
   @RequestMapping(method = RequestMethod.POST, value="/set")
-  public @ResponseBody ContactInformation setContactInformation(HttpServletRequest request, 
-                                                                  @RequestBody ContactInformation ci,
-                                                                  HttpServletResponse response) {
+  public @ResponseBody ContactInformation setContactInformation(
+          HttpServletRequest request, 
+          @RequestBody ContactInformation ci,
+          HttpServletResponse response) {
     final String uid = request.getHeader("uid");
-    //TODO validate
-    if(StringUtils.isNotBlank(uid)) {
-      try {
-        ci = service.setContactInfo(uid, ci);
-      } catch (Exception e) {
-        logger.error("Issue while user {} attempted to save {}", uid, ci.toStringForLogging(), e);
-        response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
-        return ci;
-      }
-      logger.info("User {} saved Local Contact Information successfully", uid);
-    }else{
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    
+    if (StringUtils.isBlank(uid)) {
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      return null;
     }
-    return ci;
+    
+    try {
+      service.setContactInfo(uid, ci);
+      logger.info("User {} saved Local Contact Information successfully", uid);
+    } catch (Exception e) {
+      String maskedData = MaskedLoggables.toStringForLogging(ci);
+      logger.error("Issue while user {} attempted to save {}", uid, maskedData, e);
+      response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    }
+    return service.getContactInfo(uid);
   }
 
 }

--- a/my-profile-webapp/src/main/webapp/my-app/lec/controllers.js
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/controllers.js
@@ -111,7 +111,7 @@ define(['angular'], function(angular) {
         .then(function(result){//success
           $scope.editMode = false;
         },function(data, status){//error
-          $rootScope.alerts.push({ msg: "There was an issue saving your emergency phone, please try again later.", type: 'danger'});
+          $rootScope.$emit('alert', { msg: "There was an issue saving your emergency phone, please try again later.", type: 'danger'});
         });
     };
 
@@ -132,7 +132,7 @@ define(['angular'], function(angular) {
         }, function(result, status){//error
           $rootScope.profileLoadingState.ephone = false;
           $scope.emergencyPhoneNumbers = [];
-          $rootScope.alerts.push({ msg: "There was an issue getting your phone number information. Please try again later.", type: 'danger'});
+          $rootScope.$emit('alert', { msg: "There was an issue getting your phone number information. Please try again later.", type: 'danger'});
         });
     };
 
@@ -158,7 +158,7 @@ define(['angular'], function(angular) {
                   $scope.notSaving = true;
               },function(data, status){//error
                   $scope.notSaving = true;
-                  $rootScope.alerts.push({ msg: "There was an issue saving your address, please try again later.", type: 'danger'});
+                  $rootScope.$emit('alert', { msg: "There was an issue saving your address, please try again later.", type: 'danger'});
               });
       }
 
@@ -196,7 +196,7 @@ define(['angular'], function(angular) {
               }, function(result, status){//error
                 $scope.contactInfo = {};
                 $rootScope.profileLoadingState.lcontact = false;
-                $rootScope.alerts.push({ msg: "There was an issue getting your local address information. Please try again later.", type: 'danger'});
+                $rootScope.$emit('alert', { msg: "There was an issue getting your local address information. Please try again later.", type: 'danger'});
             });
           if ( $scope.contactInfo.length === 0 ) {
             $scope.noAddresses = true;
@@ -232,7 +232,7 @@ define(['angular'], function(angular) {
                   $scope.notSaving = true;
               },function(data, status){//error
                   $scope.notSaving = true;
-                  $rootScope.alerts.push({ msg: "There was an issue saving your emergency contact, please try again later.", type: 'danger'});
+                  $rootScope.$emit('alert', { msg: "There was an issue saving your emergency contact, please try again later.", type: 'danger'});
               });
       }
 
@@ -269,8 +269,8 @@ define(['angular'], function(angular) {
               }, function(result, status){//error
                 $rootScope.profileLoadingState.einfo = false;
                 $scope.emergencyInfo = {};
-                $rootScope.alerts.push({ msg: "There was an issue getting your local address information. Please try again later.", type: 'danger'});
-                  console.log('inside getEmergencyContactInfo error state: ' + typeof $scope.emergencyInfo);
+                $rootScope.$emit('alert', { msg: "There was an issue getting your local address information. Please try again later.", type: 'danger'});
+                console.log('inside getEmergencyContactInfo error state: ' + typeof $scope.emergencyInfo);
             });
           if ( $scope.emergencyInfo.length === 0 ) {
             $scope.noContacts = true;
@@ -282,11 +282,24 @@ define(['angular'], function(angular) {
 
     }]);
     
-    app.controller('ErrorController', ['$scope','$rootScope', function($scope, $rootScope) {
-      $rootScope.alerts = [];
+    app.controller('ErrorController', ['$scope','$rootScope','$mdDialog', function($scope, $rootScope, $mdDialog) {
+      $scope.alert = {
+        title: 'Error!',
+        msg: ''
+      };
       
-      $scope.closeAlert = function(index) {
-        $rootScope.alerts.splice(index, 1);
+      $rootScope.$on('alert', function(event, data) {
+        $scope.alert.msg = data.msg;
+        $mdDialog.show({
+          templateUrl: 'alert.html',
+          parent: angular.element(document).find('div.my-uw')[0],
+          clickOutsideToClose: true,
+          preserveScope: true,
+          scope: $scope
+        })
+      });
+      $scope.close = function() {
+        $mdDialog.hide();
       };
     }]);
 });

--- a/my-profile-webapp/src/main/webapp/my-app/lec/controllers.js
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/controllers.js
@@ -107,7 +107,7 @@ define(['angular'], function(angular) {
     };
     
     $scope.save = function() {
-      lecService.saveEmergencyPhoneNumber($scope.emergencyPhoneNumbers.emergencyPhoneNumbers)
+      lecService.saveEmergencyPhoneNumber($scope.emergencyPhoneNumbers)
         .then(function(result){//success
           $scope.editMode = false;
         },function(data, status){//error
@@ -126,12 +126,12 @@ define(['angular'], function(angular) {
         .then(function(result){//success
           $rootScope.profileLoadingState.ephone = false;
           $scope.emergencyPhoneNumbers = result.data;
-          if ( $scope.emergencyPhoneNumbers.emergencyPhoneNumbers.length === 0 ) {
+          if ( $scope.emergencyPhoneNumbers.length === 0 ) {
               $scope.empty = true;
           }
         }, function(result, status){//error
           $rootScope.profileLoadingState.ephone = false;
-          $scope.emergencyPhoneNumbers = {};
+          $scope.emergencyPhoneNumbers = [];
           $rootScope.alerts.push({ msg: "There was an issue getting your phone number information. Please try again later.", type: 'danger'});
         });
     };

--- a/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-info.html
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-info.html
@@ -14,14 +14,27 @@
 
   <!-- error state -->
   <div layout="row" ng-controller='ErrorController as errorCtrl'>
-    <div flex="100">
-      <script type="text/ng-template" id="alert.html">
-        <div class="alert" role="alert">
-          <div ng-transclude></div>
-        </div>
-      </script>
-      <alert ng-repeat="alert in alerts" type="{{alert.type}}" close="closeAlert($index)">{{ alert.msg }}</alert>
-    </div>
+    <script type="text/ng-template" id="alert.html">
+      <md-dialog aria-label="error notification">
+        <md-toolbar class="md-accent">
+          <div class="md-toolbar-tools">
+            <h1>{{ alert.title }}</h1>
+            <span flex></span>
+            <md-button class="md-icon-button" ng-click="close()" aria-label="close features dialog">
+              <md-icon>close</md-icon>
+            </md-button>
+          </div>
+        </md-toolbar>
+        <md-dialog-content>
+          <div class="md-dialog-content" layout="column" layout-align="center center">
+            <p id="alertContent">{{ alert.msg }}</p>
+          </div>
+        </md-dialog-content>
+        <md-dialog-actions>
+          <md-button class="md-accent md-raised" ng-click="close()">Close</md-button>
+        </md-dialog-actions>
+      </md-dialog>
+    </script>
   </div>
 
   <!-- loading state -->

--- a/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-phone.html
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency-phone.html
@@ -1,6 +1,6 @@
 <div ng-controller="EmergencyPhoneController as EmergencyPhoneCtrl">
   <loading-gif data-object="emergencyPhoneNumbers" data-reuse="true"></loading-gif>
-  <md-card ng-show="empty || emergencyPhoneNumbers.emergencyPhoneNumbers.length>0" class="contact-info-card" flex>
+  <md-card ng-show="empty || emergencyPhoneNumbers.length>0" class="contact-info-card" flex>
     <md-card-title>
       <md-card-title-text>
         <h2 class="md-headline">Phone number</h2>
@@ -11,14 +11,14 @@
         <p>A number where you can be reached in an emergency.</p>
       </div>
       <!-- Empty state -->
-      <div ng-if="emergencyPhoneNumbers.emergencyPhoneNumbers.length === 0 && !editMode" >
+      <div ng-if="emergencyPhoneNumbers.length === 0 && !editMode" >
         <p><md-icon>warning</md-icon> No phone number entered yet.</p>
         <md-button aria-label="Add phone number" class="md-accent md-raised no-margin-left" ng-click="edit()">Add phone number</md-button>
       </div>
       <!-- Non-empty -->
-      <div ng-if="!editMode && emergencyPhoneNumbers.emergencyPhoneNumbers.length" layout="row" layout-align="space-between center">
+      <div ng-if="!editMode && emergencyPhoneNumbers.length" layout="row" layout-align="space-between center">
         <span class="md-subhead" flex="80">
-          {{ emergencyPhoneNumbers.emergencyPhoneNumbers[0].value}} ({{emergencyPhoneNumbers.emergencyPhoneNumbers[0].type }})
+          {{ emergencyPhoneNumbers[0].value}} ({{emergencyPhoneNumbers[0].type }})
         </span>
         <md-button class="md-icon-button" aria-label="edit phone number" ng-click="edit()">
           <md-icon>mode_edit</md-icon>
@@ -31,11 +31,11 @@
           <br>
           <md-input-container class="md-block" flex-gt-sm>
             <label>Phone number*</label>
-            <input type="tel" required aria-required="true" ng-pattern=/^([a-zA-Z0-9\s!-.]{1,30})$/ ng-maxlength="30" ng-model="emergencyPhoneNumbers.emergencyPhoneNumbers[0].value">
+            <input type="tel" required aria-required="true" ng-pattern=/^([a-zA-Z0-9\s!-.]{1,30})$/ ng-maxlength="30" ng-model="emergencyPhoneNumbers[0].value">
           </md-input-container>
           <md-input-container class="md-block" flex-gt-sm>
             <label>Type*</label>
-            <md-select required aria-required="true" ng-model="emergencyPhoneNumbers.emergencyPhoneNumbers[0].type">
+            <md-select required aria-required="true" ng-model="emergencyPhoneNumbers[0].type">
               <md-option value="mobile">Mobile</md-option>
               <md-option value="home">Home</md-option>
               <md-option value="work">Work</md-option>

--- a/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency.html
+++ b/my-profile-webapp/src/main/webapp/my-app/lec/partials/emergency.html
@@ -20,7 +20,7 @@
     <md-tooltip md-delay="500">Delete</md-tooltip>
   </md-button>
 </md-list-item>
-<md-divider ng-if="emergencyInfo.length > 1 && (!contact.edit || contact.edit == false")></md-divider>
+<md-divider ng-if="emergencyInfo.length > 1 && (!contact.edit || contact.edit == false)"></md-divider>
 <!-- edit emergency contacts -->
 <div ng-if="contact.edit">
   <form name="emergencyForm" novalidate class="emergency-info">

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <frame.version>5.0.0</frame.version>
+        <frame.version>6.0.4</frame.version>
         <spring.version>3.1.3.RELEASE</spring.version>
         <joda.version>2.7</joda.version>
         <jackson.version>2.2.2</jackson.version>
@@ -52,8 +52,8 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-              <groupId>edu.wisc.my.apps</groupId>
-              <artifactId>uw-frame</artifactId>
+              <groupId>org.apereo.uportal</groupId>
+              <artifactId>uportal-app-framework</artifactId>
               <version>${frame.version}</version>
               <type>war</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
     </scm>
 
     <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
         <frame.version>5.0.0</frame.version>
         <spring.version>3.1.3.RELEASE</spring.version>
         <joda.version>2.7</joda.version>
@@ -79,6 +81,11 @@
               <version>${gson-jodaTime-serializer.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>23.4-jre</version>
+            </dependency>
             <dependency>
                 <groupId>commons-dbcp</groupId>
                 <artifactId>commons-dbcp</artifactId>


### PR DESCRIPTION
Error Messaging much more visible:
![image](https://user-images.githubusercontent.com/937952/33100542-62ab6b44-ceda-11e7-88c3-0424ad7570d7.png)

And UTF-8 Characters are retained through the process:
![image](https://user-images.githubusercontent.com/937952/33100581-8fe429c0-ceda-11e7-9aa9-f4eec9121bde.png)


Included:
* Server-side controllers responding with last saved object on set
* String masking pulled out to an interface
* Fix for small front-end syntax error
* Client-side error notification is now a dialog box controlled by events
* Fix for just including _any_ UTF-8 characters that caused the service to break.

would be nice to have:
* Client-side to verify fields of last saved object against the fields it has
* Reduce down to one properly configured JSON serializer, rather than three
* Verify we're using Java 8 to build and run, then use streams rather than guava