### PR TITLE
using catalina.base to set log directory

### DIFF
--- a/my-profile-webapp/src/main/resources/logback.xml
+++ b/my-profile-webapp/src/main/resources/logback.xml
@@ -30,22 +30,22 @@
 <configuration scan="true" scanPeriod="30 seconds">
     <contextName>profile</contextName>
 
-  <!-- 
-   | Propagate log levels to java.util.logging 
+  <!--
+   | Propagate log levels to java.util.logging
    +-->
   <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
     <resetJUL>true</resetJUL>
   </contextListener>
 
-  <!-- 
-   | Expose the logback configuration via JMX 
+  <!--
+   | Expose the logback configuration via JMX
    +-->
   <jmxConfigurator />
 
-  <!-- 
+  <!--
    | Specify a local property that sets up the logging directory
    +-->
-  <property scope="local" name="LOG_DIR" value="${profile.webapp.root}/../../logs/${CONTEXT_NAME}" />
+  <property scope="local" name="LOG_DIR" value="${catalina.base}/logs/${CONTEXT_NAME}" />
 
     <appender name="LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <!--See http://logback.qos.ch/manual/appenders.html#RollingFileAppender-->


### PR DESCRIPTION
I got annoyed that the `run_local.sh` was pumping logs into the sources directory, making the logs dir immune to `mvn clean`

This fixes that by using `${catalina.base}` to find the tomcat's log directory, placing the logs in `target/tomcat/logs`

This also includes some editor enforced whitespace changes.